### PR TITLE
feat: Handle errors from API

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -102,5 +102,5 @@ input:-moz-ui-invalid {
   width: 1em;
   height: 1em;
   display: inline-block;
-  vertical-align: -0.125em;
+  vertical-align: -0.175em;
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -48,6 +48,9 @@
     "label": "Taal"
   },
   "api": {
-    "NotFoundError": "No term found with this URI"
+    "ServerError": "The term source could not process the request",
+    "TimeoutError": "The term source is temporarily unavailable",
+    "NotFoundError": "No term found with this URI",
+    "Error": "An error occurred"
   }
 }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -49,7 +49,7 @@
   },
   "api": {
     "ServerError": "De terminologiebron kon de vraag niet verwerken",
-    "TimeoutError": "De terminologiebron is tijdelijk  niet bereikbaar",
+    "TimeoutError": "De terminologiebron is tijdelijk niet bereikbaar",
     "NotFoundError": "Geen term gevonden met deze URI",
     "Error": "Er is een fout opgetreden"
   }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -48,6 +48,9 @@
     "label": "Language"
   },
   "api": {
-    "NotFoundError": "Geen term gevonden met deze URI"
+    "ServerError": "De terminologiebron kon de vraag niet verwerken",
+    "TimeoutError": "De terminologiebron is tijdelijk  niet bereikbaar",
+    "NotFoundError": "Geen term gevonden met deze URI",
+    "Error": "Er is een fout opgetreden"
   }
 }

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,10 +1,19 @@
-export interface TermsQuery {
+export interface TermsQueryResult {
   terms: [
     {
       source: Source,
-      terms: Term[],
+      result: Terms | Error,
     },
   ]
+}
+
+export interface Terms {
+  terms: Term[];
+}
+
+export interface Error {
+  __typename: string;
+  message: string;
 }
 
 export interface LookupQuery {


### PR DESCRIPTION
Show errors like this:

<img width="1492" alt="Screenshot 2021-12-09 at 11 21 17" src="https://user-images.githubusercontent.com/89267/145378704-12ac206c-e7df-4837-b44e-35f8272973e4.png">

Rather in your face, but at least users will see what is going on.

Fix #354.﻿
