### PR TITLE
fix: Replace scale hover with color change

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -36,8 +36,9 @@ button.btn-light:focus {
 }
 
 .card:hover {
-  transition: .2s;
-  transform: scale(1.03);
+  transition: .1s;
+  border: 1px solid rgba(0, 0, 0, .3);
+  background-color: rgba(0, 0, 0, .05) !important;
 }
 
 .termCount {


### PR DESCRIPTION
* The scale transform, relative by definition, caused large cards to
  overlap other cards.

Fix #430.
