### PR TITLE
build: Fix deprecation

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,11 +3,13 @@ module.exports = {
   parser: 'vue-eslint-parser',
 
   env: {
-    node: true,
+    browser: true,
+    es2021: true
   },
 
   plugins: [
     '@typescript-eslint',
+    'vue',
   ],
 
   extends: [
@@ -17,7 +19,8 @@ module.exports = {
   ],
 
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 'latest',
+    parser: '@typescript-eslint/parser',
   },
 
   rules: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "network-of-terms-demo",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",


### PR DESCRIPTION
See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated
