### PR TITLE
Open term source in new tab

### DIFF
--- a/src/components/TermResult.vue
+++ b/src/components/TermResult.vue
@@ -41,6 +41,7 @@
 
         <a
           :href="term.seeAlso[0] ?? term.uri"
+          target="_blank"
           class="btn btn-primary ml-2"
         >
           {{ t('search.viewAtSource') }}


### PR DESCRIPTION
When inspecting a source it currently opens the source in the current tab. However when you are just browsing it may be desirable to open the source in a new tab instead. This PR fixes that.

It could be considered to do the same for any link referring to another site, but I'll leave that out of the scope of this PR.

Closes https://github.com/netwerk-digitaal-erfgoed/network-of-terms-demo/issues/967